### PR TITLE
Add --encode_b64 option to encode message payloads as base64 encoded strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,23 @@ Simple cli tool for recording and replaying MQTT messages.
 `pip install mqtt-recorder`
 
 ## Usage
-|  Argument   |                       Description                      | Required | Default |
-|:-----------:|:------------------------------------------------------:|----------|:-------:|
-| -h, --help  | Show help                                              |          |         |
-| --host      | MQTT broker address                                    |     x    |         |
-| --port      | MQTT broker port                                       |          | 1883    |
-| --mode      | mode: record/replay                                    |     x    |         |
-| --file      | output/input csv file                                  |     x    |         |
-| --loop      | looping replay                                         |          | false   |
-| --qos       | Quality of Service that will be used for subscriptions |          | 0       |
-| --topics    | json file containing selected topics for subscriptions |          | null    |
-| --enable_ssl| True to enable MQTTs support, False otherwise          |          | False   |
-| --ca_cert   | Path to the Certificate Authority certificate files    |          | None    |
-| --certfile  | Path to the client certificate                         |          | None    |
-| --keyfile   | Path to the client private key                         |          | None    |
-| --username  | MQTT broker username                                   |          | None    |
-| --password  | MQTT broker password                                   |          | None    |
+|   Argument   |                        Description                       | Required | Default |
+|:------------:|:--------------------------------------------------------:|----------|:-------:|
+| -h, --help   | Show help                                                |          |         |
+| --host       | MQTT broker address                                      |     x    |         |
+| --port       | MQTT broker port                                         |          | 1883    |
+| --mode       | mode: record/replay                                      |     x    |         |
+| --file       | output/input csv file                                    |     x    |         |
+| --loop       | looping replay                                           |          | false   |
+| --qos        | Quality of Service that will be used for subscriptions   |          | 0       |
+| --topics     | json file containing selected topics for subscriptions   |          | null    |
+| --enable_ssl | True to enable MQTTs support, False otherwise            |          | False   |
+| --ca_cert    | Path to the Certificate Authority certificate files      |          | None    |
+| --certfile   | Path to the client certificate                           |          | None    |
+| --keyfile    | Path to the client private key                           |          | None    |
+| --username   | MQTT broker username                                     |          | None    |
+| --password   | MQTT broker password                                     |          | None    |
+| --encode_b64 | True to store message payloads as base64 encoded strings |          | False   |
 ### Recording
 #### Subscribing to every topic
 `mqtt-recorder --host localhost --mode record --file recording.csv`

--- a/mqtt_recorder/__main__.py
+++ b/mqtt_recorder/__main__.py
@@ -72,7 +72,7 @@ parser.add_argument(
 
 parser.add_argument(
     '--mode',
-    type=str,
+    choices=["record", "replay"],
     help='mode: record/replay',
     required=True
 )
@@ -104,6 +104,14 @@ parser.add_argument(
     help='json file containing selected topics for subscriptions'
 )
 
+parser.add_argument(
+    '--encode_b64',
+    default=False,
+    action='store_true',
+    help='Store raw data as base64 encoded string in CSV file instead of UTF-8 encoded string. '
+         'Should be used to record binary message payloads'
+)
+
 
 def wait_for_keyboard_interrupt():
     try:
@@ -116,7 +124,14 @@ def wait_for_keyboard_interrupt():
 def main():
     args = parser.parse_args()
     sslContext = SslContext(args.enable_ssl, args.ca_cert, args.certfile, args.keyfile)
-    recorder = MqttRecorder(args.host, args.port, args.file, args.username, args.password, sslContext)
+    recorder = MqttRecorder(
+        args.host,
+        args.port,
+        args.file,
+        args.username,
+        args.password,
+        sslContext,
+        args.encode_b64)
     if args.mode == 'record':
         recorder.start_recording(qos=args.qos, topics_file=args.topics)
         wait_for_keyboard_interrupt()


### PR DESCRIPTION
This option should be used when MQTT message payloads are containing binary data.

When recording, save bytes payload as base64 encoded string in CSV file
When replaying, decode the payload from base64 string