### PR TITLE
feat: add --csv-field-size-limit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Simple cli tool for recording and replaying MQTT messages.
 | --username             | MQTT broker username                                     |          | None    |
 | --password             | MQTT broker password                                     |          | None    |
 | --encode_b64           | True to store message payloads as base64 encoded strings |          | False   |
-| --csv_field_size_limit | True to store message payloads as base64 encoded strings |          | False   |
+| --csv_field_size_limit | CSV field size limit |          | False   |
 
 
 ### Recording

--- a/README.md
+++ b/README.md
@@ -7,25 +7,28 @@ Simple cli tool for recording and replaying MQTT messages.
 `pip install mqtt-recorder`
 
 ## Usage
-|   Argument   |                        Description                       | Required | Default |
-|:------------:|:--------------------------------------------------------:|----------|:-------:|
-| -h, --help   | Show help                                                |          |         |
-| --host       | MQTT broker address                                      |     x    |         |
-| --port       | MQTT broker port                                         |          | 1883    |
-| --client_id  | MQTT Client ID                                           |          |         |
-| --mode       | mode: record/replay                                      |     x    |         |
-| --file       | output/input csv file                                    |     x    |         |
-| --loop       | looping replay                                           |          | false   |
-| --qos        | Quality of Service that will be used for subscriptions   |          | 0       |
-| --topics     | json file containing selected topics for subscriptions   |          | null    |
-| --enable_ssl | True to enable MQTTs support, False otherwise            |          | False   |
-| --tls_insecure| If certs is self-generated, change to True              |          | False   |
-| --ca_cert    | Path to the Certificate Authority certificate files      |          | None    |
-| --certfile   | Path to the client certificate                           |          | None    |
-| --keyfile    | Path to the client private key                           |          | None    |
-| --username   | MQTT broker username                                     |          | None    |
-| --password   | MQTT broker password                                     |          | None    |
-| --encode_b64 | True to store message payloads as base64 encoded strings |          | False   |
+| Argument               | Description                                              | Required | Default |
+| ---------------------- | -------------------------------------------------------- | -------- | ------- |
+| -h, --help             | Show help                                                |          |         |
+| --host                 | MQTT broker address                                      | x        |         |
+| --port                 | MQTT broker port                                         |          | 1883    |
+| --client_id            | MQTT Client ID                                           |          |         |
+| --mode                 | mode: record/replay                                      | x        |         |
+| --file                 | output/input csv file                                    | x        |         |
+| --loop                 | looping replay                                           |          | false   |
+| --qos                  | Quality of Service that will be used for subscriptions   |          | 0       |
+| --topics               | json file containing selected topics for subscriptions   |          | null    |
+| --enable_ssl           | True to enable MQTTs support, False otherwise            |          | False   |
+| --tls_insecure         | If certs is self-generated, change to True               |          | False   |
+| --ca_cert              | Path to the Certificate Authority certificate files      |          | None    |
+| --certfile             | Path to the client certificate                           |          | None    |
+| --keyfile              | Path to the client private key                           |          | None    |
+| --username             | MQTT broker username                                     |          | None    |
+| --password             | MQTT broker password                                     |          | None    |
+| --encode_b64           | True to store message payloads as base64 encoded strings |          | False   |
+| --csv_field_size_limit | True to store message payloads as base64 encoded strings |          | False   |
+
+
 ### Recording
 #### Subscribing to every topic
 `mqtt-recorder --host localhost --mode record --file recording.csv`

--- a/mqtt_recorder/__main__.py
+++ b/mqtt_recorder/__main__.py
@@ -1,6 +1,7 @@
 from mqtt_recorder.recorder import MqttRecorder, SslContext
 import argparse
 import time
+import csv
 
 parser = argparse.ArgumentParser(
     prog='mqtt_recorder',
@@ -129,6 +130,12 @@ parser.add_argument(
          'Should be used to record binary message payloads'
 )
 
+parser.add_argument(
+    '--csv-field-size-limit',
+    default=None,
+    type=int,
+    help='Set csv.field_size_limit(VALUE)'
+)
 
 def wait_for_keyboard_interrupt():
     try:
@@ -140,6 +147,9 @@ def wait_for_keyboard_interrupt():
 
 def main():
     args = parser.parse_args()
+    if args.csv_field_size_limit and args.csv_field_size_limit > 0:
+        csv.field_size_limit(args.csv_field_size_limit)
+        print(f"setting csv limit to: {args.csv_field_size_limit}")
     sslContext = SslContext(args.enable_ssl, args.ca_cert, args.certfile, args.keyfile, args.tls_insecure)
     recorder = MqttRecorder(
         args.host,

--- a/mqtt_recorder/__main__.py
+++ b/mqtt_recorder/__main__.py
@@ -149,7 +149,6 @@ def main():
     args = parser.parse_args()
     if args.csv_field_size_limit and args.csv_field_size_limit > 0:
         csv.field_size_limit(args.csv_field_size_limit)
-        print(f"setting csv limit to: {args.csv_field_size_limit}")
     sslContext = SslContext(args.enable_ssl, args.ca_cert, args.certfile, args.keyfile, args.tls_insecure)
     recorder = MqttRecorder(
         args.host,

--- a/mqtt_recorder/__main__.py
+++ b/mqtt_recorder/__main__.py
@@ -131,7 +131,7 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    '--csv-field-size-limit',
+    '--csv_field_size_limit',
     default=None,
     type=int,
     help='Set csv.field_size_limit(VALUE)'


### PR DESCRIPTION
My use case for MQTT deals with heavy binary payloads.

In order to make it work, I need to encode as base64, but at the moment of replaying the session, I need to increase python's csv library field limit.